### PR TITLE
Other solution for fifth and eighth steps

### DIFF
--- a/03_Grouping/Occupation/Exercises_with_solutions.ipynb
+++ b/03_Grouping/Occupation/Exercises_with_solutions.ipynb
@@ -200,28 +200,28 @@
     {
      "data": {
       "text/plain": [
-       "doctor           100.000000\n",
-       "engineer          97.014925\n",
-       "technician        96.296296\n",
-       "retired           92.857143\n",
-       "programmer        90.909091\n",
-       "executive         90.625000\n",
-       "scientist         90.322581\n",
-       "entertainment     88.888889\n",
-       "lawyer            83.333333\n",
-       "salesman          75.000000\n",
-       "educator          72.631579\n",
-       "student           69.387755\n",
-       "other             65.714286\n",
-       "marketing         61.538462\n",
-       "writer            57.777778\n",
-       "none              55.555556\n",
-       "administrator     54.430380\n",
-       "artist            53.571429\n",
-       "librarian         43.137255\n",
-       "healthcare        31.250000\n",
-       "homemaker         14.285714\n",
-       "dtype: float64"
+       "occupation     gender\n"
+       "doctor         M         1.000000\n"
+       "engineer       M         0.970149\n"
+       "technician     M         0.962963\n"
+       "retired        M         0.928571\n"
+       "programmer     M         0.909091\n"
+       "executive      M         0.906250\n"
+       "scientist      M         0.903226\n"
+       "entertainment  M         0.888889\n"
+       "lawyer         M         0.833333\n"
+       "salesman       M         0.750000\n"
+       "educator       M         0.726316\n"
+       "student        M         0.693878\n"
+       "other          M         0.657143\n"
+       "marketing      M         0.615385\n"
+       "writer         M         0.577778\n"
+       "none           M         0.555556\n"
+       "administrator  M         0.544304\n"
+       "artist         M         0.535714\n"
+       "librarian      M         0.431373\n"
+       "healthcare     M         0.312500\n"
+      "homemaker      M         0.142857\n"
       ]
      },
      "execution_count": 150,
@@ -230,21 +230,7 @@
     }
    ],
    "source": [
-    "# create a function\n",
-    "def gender_to_numeric(x):\n",
-    "    if x == 'M':\n",
-    "        return 1\n",
-    "    if x == 'F':\n",
-    "        return 0\n",
-    "\n",
-    "# apply the function to the gender column and create a new column\n",
-    "users['gender_n'] = users['gender'].apply(gender_to_numeric)\n",
-    "\n",
-    "\n",
-    "a = users.groupby('occupation').gender_n.sum() / users.occupation.value_counts() * 100 \n",
-    "\n",
-    "# sort to the most male \n",
-    "a.sort_values(ascending = False)"
+    "users.groupby('occupation')['gender'].value_counts(normalize=True).drop(labels='F', level=1).sort_values(ascending=False)"
    ]
   },
   {
@@ -511,48 +497,48 @@
     {
      "data": {
       "text/plain": [
-       "occupation     gender\n",
-       "administrator  F          45.569620\n",
-       "               M          54.430380\n",
-       "artist         F          46.428571\n",
-       "               M          53.571429\n",
-       "doctor         M         100.000000\n",
-       "educator       F          27.368421\n",
-       "               M          72.631579\n",
-       "engineer       F           2.985075\n",
-       "               M          97.014925\n",
-       "entertainment  F          11.111111\n",
-       "               M          88.888889\n",
-       "executive      F           9.375000\n",
-       "               M          90.625000\n",
-       "healthcare     F          68.750000\n",
-       "               M          31.250000\n",
-       "homemaker      F          85.714286\n",
-       "               M          14.285714\n",
-       "lawyer         F          16.666667\n",
-       "               M          83.333333\n",
-       "librarian      F          56.862745\n",
-       "               M          43.137255\n",
-       "marketing      F          38.461538\n",
-       "               M          61.538462\n",
-       "none           F          44.444444\n",
-       "               M          55.555556\n",
-       "other          F          34.285714\n",
-       "               M          65.714286\n",
-       "programmer     F           9.090909\n",
-       "               M          90.909091\n",
-       "retired        F           7.142857\n",
-       "               M          92.857143\n",
-       "salesman       F          25.000000\n",
-       "               M          75.000000\n",
-       "scientist      F           9.677419\n",
-       "               M          90.322581\n",
-       "student        F          30.612245\n",
-       "               M          69.387755\n",
-       "technician     F           3.703704\n",
-       "               M          96.296296\n",
-       "writer         F          42.222222\n",
-       "               M          57.777778\n",
+       "occupation     gender\n"
+       "administrator  M         0.544304\n"
+                      "F         0.455696\n"
+       "artist         M         0.535714\n"
+                      "F         0.464286\n"
+       "doctor         M         1.000000\n"
+       "educator       M         0.726316\n"
+                      "F         0.273684\n"
+       "engineer       M         0.970149\n"
+                      "F         0.029851\n"
+       "entertainment  M         0.888889\n"
+                      "F         0.111111\n"
+       "executive      M         0.906250\n"
+                      "F         0.093750\n"
+       "healthcare     F         0.687500\n"
+                      "M         0.312500\n"
+       "homemaker      F         0.857143\n"
+                      "M         0.142857\n"
+       "lawyer         M         0.833333\n"
+                      "F         0.166667\n"
+       "librarian      F         0.568627\n"
+                      "M         0.431373\n"
+       "marketing      M         0.615385\n"
+                      "F         0.384615\n"
+       "none           M         0.555556\n"
+                      "F         0.444444\n"
+       "other          M         0.657143\n"
+                      "F         0.342857\n"
+       "programmer     M         0.909091\n"
+                      "F         0.090909\n"
+       "retired        M         0.928571\n"
+                      "F         0.071429\n"
+       "salesman       M         0.750000\n"
+                      "F         0.250000\n"
+       "scientist      M         0.903226\n"
+                      "F         0.096774\n"
+       "student        M         0.693878\n"
+                      "F         0.306122\n"
+       "technician     M         0.962963\n"
+                      "F         0.037037\n"
+       "writer         M         0.577778\n"
+                      "F         0.422222\n"
        "Name: gender, dtype: float64"
       ]
      },
@@ -562,17 +548,7 @@
     }
    ],
    "source": [
-    "# create a data frame and apply count to gender\n",
-    "gender_ocup = users.groupby(['occupation', 'gender']).agg({'gender': 'count'})\n",
-    "\n",
-    "# create a DataFrame and apply count for each occupation\n",
-    "occup_count = users.groupby(['occupation']).agg('count')\n",
-    "\n",
-    "# divide the gender_ocup per the occup_count and multiply per 100\n",
-    "occup_gender = gender_ocup.div(occup_count, level = \"occupation\") * 100\n",
-    "\n",
-    "# present all rows from the 'gender column'\n",
-    "occup_gender.loc[: , 'gender']"
+    "users.groupby('occupation')['gender'].value_counts(normalize=True)"
    ]
   }
  ],


### PR DESCRIPTION
Fifth step (and eighth too) can be easily done using only groupby through some working with multiindex.
For fifth step is
`users.groupby('occupation')['gender'].value_counts(normalize=True).drop(labels='F', level=1).sort_values(ascending=False)`
And for eighth step is
`users.groupby('occupation')['gender'].value_counts(normalize=True)`